### PR TITLE
空間写真生成パラメータをGUIで調整可能にする

### DIFF
--- a/SpatialPhoto/Views/Generate/GenerateSplitView.swift
+++ b/SpatialPhoto/Views/Generate/GenerateSplitView.swift
@@ -20,6 +20,10 @@ struct GenerateSplitView: View {
   @State var error: (any Error)?
   @State var isSaveSuccessAlertPresented: Bool = false
 
+  @State var baselineInMillimeters: Double = 10
+  @State var horizontalFOV: Double = 42
+  @State var disparityAdjustment: Double = 0
+
   enum ImageType {
     case left
     case right
@@ -125,6 +129,27 @@ struct GenerateSplitView: View {
         )
       }
       .padding(16)
+
+      VStack(spacing: 12) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Baseline (mm): \(String(format: "%.1f", baselineInMillimeters))")
+            .font(.caption)
+          Slider(value: $baselineInMillimeters, in: 1...100, step: 0.5)
+        }
+        
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Horizontal FOV: \(String(format: "%.1f", horizontalFOV))")
+            .font(.caption)
+          Slider(value: $horizontalFOV, in: 10...120, step: 1)
+        }
+        
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Disparity Adjustment: \(String(format: "%.2f", disparityAdjustment))")
+            .font(.caption)
+          Slider(value: $disparityAdjustment, in: -10...10, step: 0.1)
+        }
+      }
+      .padding(.horizontal, 16)
 
       if leftImage != nil && rightImage == nil {
         Button {
@@ -349,9 +374,9 @@ struct GenerateSplitView: View {
       leftImageURL: leftImageURL,
       rightImageURL: rightImageURL,
       outputImageURL: outputImageURL,
-      baselineInMillimeters: 10,
-      horizontalFOV: 42,
-      disparityAdjustment: 0
+      baselineInMillimeters: baselineInMillimeters,
+      horizontalFOV: horizontalFOV,
+      disparityAdjustment: disparityAdjustment
     )
     try converter.convert()
 


### PR DESCRIPTION
## 概要
空間写真生成時のパラメータ（baseline、horizontalFOV、disparityAdjustment）をGUIで調整できるようにしました。

## 変更内容
- 3つの調整可能なState変数を追加
  - `baselineInMillimeters`: ベースライン（mm単位）
  - `horizontalFOV`: 水平視野角（度）
  - `disparityAdjustment`: 視差調整
- 各パラメータ用のSlider UIを実装
  - Baseline: 1-100mm（0.5mmステップ）
  - Horizontal FOV: 10-120度（1度ステップ）
  - Disparity Adjustment: -10〜10（0.1ステップ）
- ハードコードされた値を調整可能な変数に置き換え

## スクリーンショット
画像選択エリアの下に3つのスライダーが表示されます。

## 動作確認
- [ ] スライダーで各パラメータを変更できる
- [ ] 変更したパラメータで空間写真が正しく生成される
- [ ] 画像分割からの生成も正しく動作する